### PR TITLE
Fix class attributes in React pages

### DIFF
--- a/react/codicon/src/pages/bigbang.jsx
+++ b/react/codicon/src/pages/bigbang.jsx
@@ -60,7 +60,7 @@ function Bigbang() {
                 </div>
 
                 <div id="text">     
-                    <p class="transparent"><h1 class="transparent">Caja Universal</h1>
+                    <p className="transparent"><h1 className="transparent">Caja Universal</h1>
                     <br />
                     Cada vez que nos proponemos un objetivo, nos embarcamos en una aventura llena de incertidumbres 
                     y sorpresas. Como abrir una caja, el camino hacia nuestros objetivos es un proceso en el que no sabemos con certeza qué 
@@ -72,13 +72,13 @@ function Bigbang() {
                 </div>
 
                 <Link to="/system" id="nexts">
-                    <div class="transparent">
-                        <p class="transparent" id="trulu">Siguiente</p> <img src={cerrada} id="omegalil" alt="" />
+                    <div className="transparent">
+                        <p className="transparent" id="trulu">Siguiente</p> <img src={cerrada} id="omegalil" alt="" />
                     </div>
                 </Link>
 
-                <div class="transparent">
-                    <p id="nebultext" class="transparent">Esta es la Nebulosa de Orion
+                <div className="transparent">
+                    <p id="nebultext" className="transparent">Esta es la Nebulosa de Orion
                     <br />
                     La Nebulosa de Orión es una nebulosa brillante en el cielo nocturno, también conocida 
                     como Messier 42 o NGC 1976. Se encuentra en la constelación de Orión, a unos 1.344 años luz de distancia 
@@ -89,7 +89,7 @@ function Bigbang() {
                     <div id="pruv" onClick={apple}/>
                 </div>
 
-                <div class="polvo">
+                <div className="polvo">
                     <div>
                         <img id="nebulosa" src={nebulosa} alt="" />
                     </div>

--- a/react/codicon/src/pages/blackhole.jsx
+++ b/react/codicon/src/pages/blackhole.jsx
@@ -38,9 +38,9 @@ function Blackhole () {
                     <div className="odo">
                         <div className="lanetas">
                         
-                        <div class="agh">
+                        <div className="agh">
                             <Stars></Stars>
-                            <div class="loco" onClick={appereance}>
+                            <div className="loco" onClick={appereance}>
                                 <img id="mecorro" src={cerrada} alt="" />
                             </div>
                         </div>

--- a/react/codicon/src/pages/kepler90b.jsx
+++ b/react/codicon/src/pages/kepler90b.jsx
@@ -7,9 +7,9 @@ function Kepler90b (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90b (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90b</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90b</h1>
                     <br />
                     Es el planeta más cercano a su estrella y tiene una órbita muy cercana, lo 
                     que significa que es un planeta caliente con una temperatura superficial 
@@ -38,7 +38,7 @@ function Kepler90b (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90b" src={k90b} alt="kepler90b"/>
+                <img className="freddy" id="kepler90b" src={k90b} alt="kepler90b"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90c.jsx
+++ b/react/codicon/src/pages/kepler90c.jsx
@@ -7,9 +7,9 @@ function Kepler90c (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita alrededor 
                     de su estrella, Kepler-90, que es similar al Sol en tamaño y temperatura.
                     <br />
@@ -21,9 +21,9 @@ function Kepler90c (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Keplar-90c</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Keplar-90c</h1>
                     <br />
                     Es el segundo planeta del sistema y orbita a una distancia de 0,014 UA. Tiene 
                     un tamaño similar al de la Tierra y completa una órbita alrededor de Kepler-90 
@@ -36,7 +36,7 @@ function Kepler90c (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="keplar90c" src={kepler90c} alt="keplar90c"/>
+                <img className="freddy" id="keplar90c" src={kepler90c} alt="keplar90c"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90d.jsx
+++ b/react/codicon/src/pages/kepler90d.jsx
@@ -7,9 +7,9 @@ function Kepler90d (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     Seguramente ya te habrás dado cuenta pero estas cajas no represetan el planeta que contienen,
                     Y eso es porque esta página representa el proceso a un fin y en ese proceso de alcanzar nuestros objetivos, 
                     podemos encontrarnos con situaciones que nos sorprenden y que ponen a prueba nuestra capacidad de adaptación y 
@@ -21,9 +21,9 @@ function Kepler90d (){
                     pensar que sabemos lo que hay dentro, pero en realidad es una incertidumbre que solo se despeja cuando nos atrevemos 
                     a abrirla y enfrentar lo que hay dentro.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90d</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90d</h1>
                     <br />
                     Este es el planeta más grande del sistema, con un tamaño similar a Neptuno. 
                     Es un planeta gaseoso con una densidad mucho menor que la de la Tierra.
@@ -35,7 +35,7 @@ function Kepler90d (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90d" src={k90d} alt="kepler90d"/>
+                <img className="freddy" id="kepler90d" src={k90d} alt="kepler90d"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90e.jsx
+++ b/react/codicon/src/pages/kepler90e.jsx
@@ -7,9 +7,9 @@ function Kepler90e (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90e (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90e</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90e</h1>
                     <br />
                     Este planeta es uno de los más parecidos a la Tierra en términos de tamaño 
                     y temperatura superficial. Sin embargo, su densidad es un poco mayor, lo 
@@ -37,7 +37,7 @@ function Kepler90e (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90e" src={k90e} alt="kepler90e"/>
+                <img className="freddy" id="kepler90e" src={k90e} alt="kepler90e"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90f.jsx
+++ b/react/codicon/src/pages/kepler90f.jsx
@@ -7,9 +7,9 @@ function Kepler90f (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90f (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90f</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90f</h1>
                     <br />
                     Este planeta es un poco más grande que la Tierra y tiene una temperatura 
                     superficial de alrededor de 420°C. Su densidad es similar a la de la Tierra,
@@ -37,7 +37,7 @@ function Kepler90f (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90f" src={k90f} alt="kepler90f"/>
+                <img className="freddy" id="kepler90f" src={k90f} alt="kepler90f"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90g.jsx
+++ b/react/codicon/src/pages/kepler90g.jsx
@@ -7,9 +7,9 @@ function Kepler90g (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90g (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90g</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90g</h1>
                     <br />
                     Es uno de los planetas más interesantes del sistema. Es un poco más 
                     grande que la Tierra y tiene una temperatura superficial de alrededor 
@@ -35,7 +35,7 @@ function Kepler90g (){
                 </p>
             </div>
             <div>
-                <img class="freddy" id="kepler90g" src={keplar90g} alt="kepler90g"/>
+                <img className="freddy" id="kepler90g" src={keplar90g} alt="kepler90g"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90h.jsx
+++ b/react/codicon/src/pages/kepler90h.jsx
@@ -7,9 +7,9 @@ function Kepler90h (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90h (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90h</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90h</h1>
                     <br />
                     Es un planeta bastante grande, con un tamaño similar al de Saturno. 
                     Es un planeta gaseoso con una densidad mucho menor que la de la Tierra.
@@ -36,7 +36,7 @@ function Kepler90h (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90h" src={k90h} alt="kepler90h"/>
+                <img className="freddy" id="kepler90h" src={k90h} alt="kepler90h"/>
             </div>
         </div>
     )

--- a/react/codicon/src/pages/kepler90i.jsx
+++ b/react/codicon/src/pages/kepler90i.jsx
@@ -7,9 +7,9 @@ function Kepler90i (){
     return (
         
         <div >
-            <Stars class="boy"/>
-            <div class="kek">
-                <p class="xlr8">
+            <Stars className="boy"/>
+            <div className="kek">
+                <p className="xlr8">
                     El sistema Kepler-90 tiene un total de 8 planetas confirmados en órbita 
                     alrededor de su estrella, Kepler-90, que es similar al Sol en tamaño 
                     y temperatura.
@@ -22,9 +22,9 @@ function Kepler90i (){
                     sí, lo que indica que los sistemas planetarios pueden ser más compactos 
                     de lo que se pensaba.</p>
             </div>
-            <div class="description">
-                <p class="xlr8">
-                    <h1 class="xlr8">Kepler-90i</h1>
+            <div className="description">
+                <p className="xlr8">
+                    <h1 className="xlr8">Kepler-90i</h1>
                     <br />
                     Es el planeta más alejado de la estrella y tiene una órbita muy lejana, 
                     lo que significa que es un planeta frío con una temperatura superficial 
@@ -38,7 +38,7 @@ function Kepler90i (){
                 </div>
             </div>
             <div>
-                <img class="freddy" id="kepler90i" src={k90i} alt="kepler90i"/>
+                <img className="freddy" id="kepler90i" src={k90i} alt="kepler90i"/>
             </div>
         </div>
         

--- a/react/codicon/src/pages/sistemalinks.jsx
+++ b/react/codicon/src/pages/sistemalinks.jsx
@@ -8,71 +8,71 @@ function SSSistema (){
     return(
         
         <div> 
-        <div class="planetas">
+        <div className="planetas">
             <Stars/>
-                <div class="sun"></div>
-                <div class="shadowsun"></div>
+                <div className="sun"></div>
+                <div className="shadowsun"></div>
 
-            <div class="neptuno-linea-1">
-                 <Link to="/kepler90b" class="Link">
-                     <div class="neptuno">
+            <div className="neptuno-linea-1">
+                 <Link to="/kepler90b" className="Link">
+                     <div className="neptuno">
                     </div>
                  </Link>
             </div>
 
 
-            <div class="urano-linea-1">
-                <Link to="/kepler90c" class="Link">
-                    <div class="urano">
+            <div className="urano-linea-1">
+                <Link to="/kepler90c" className="Link">
+                    <div className="urano">
                     </div>
                 </Link>
             </div>
 
-            <div class="saturno-linea-1">
-                <Link to="/kepler90d" class="Link">
-                    <div class="saturno">
+            <div className="saturno-linea-1">
+                <Link to="/kepler90d" className="Link">
+                    <div className="saturno">
                      </div>
                 </Link>
             </div>
 
-            <div class="jupiter-linea-1">
-                <Link to="/kepler90e" class="Link">
-                    <div class="jupiter">
+            <div className="jupiter-linea-1">
+                <Link to="/kepler90e" className="Link">
+                    <div className="jupiter">
                     </div>
                 </Link>
             </div>
             
-            <div class="marte-linea-1">
-                <Link to="/kepler90f" class="Link">
-                    <div class="marte">
+            <div className="marte-linea-1">
+                <Link to="/kepler90f" className="Link">
+                    <div className="marte">
                     </div>
                 </Link>
             </div>
 
-            <div class="tierra-linea-1">
-                <Link to="/kepler90b" class="Link">
-                    <div class="tierra">
+            <div className="tierra-linea-1">
+                <Link to="/kepler90b" className="Link">
+                    <div className="tierra">
                     </div>
                 </Link>
             </div>
 
-            <div class="venus-linea-1">
-                <Link to="/kepler90h" class="Link">
-                    <div class="venus">
+            <div className="venus-linea-1">
+                <Link to="/kepler90h" className="Link">
+                    <div className="venus">
                     </div>
                 </Link>
             </div>
             
-            <div class="mercurio-linea">
-                <Link to="/kepler90i" class="Link">
-                    <div class="mercurio">
+            <div className="mercurio-linea">
+                <Link to="/kepler90i" className="Link">
+                    <div className="mercurio">
                     </div>
                 </Link>
             </div>
         </div>
         <Link to="/black" id="nexts">
-                <div class="transparent">
-                     <p class="transparent">Siguiente</p> <img src={cerrada} id="omegalils" alt="" />
+                <div className="transparent">
+                     <p className="transparent">Siguiente</p> <img src={cerrada} id="omegalils" alt="" />
                 </div>
             </Link>
         </div>  

--- a/react/codicon/src/pages/stars.jsx
+++ b/react/codicon/src/pages/stars.jsx
@@ -5,9 +5,9 @@ function Stars() {
     
     <div id="body">
         
-        <div class="container">
+        <div className="container">
             
-            <div class="bubbles">        
+            <div className="bubbles">        
 
                 <span id="s"></span>
                 <span id="s2"></span>


### PR DESCRIPTION
## Summary
- fix `class` attributes in React pages by renaming them to `className`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f748e534c83208781ea8159e77f27